### PR TITLE
Add Device Firmware Update dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,6 @@ RUN apt-get update && eatmydata apt-get install openocd gdb-arm-none-eabi --no-i
 
 # Emulation dependencies
 RUN apt-get update && eatmydata apt-get install qemu-system-arm --no-install-recommends -y && rm -rf /var/lib/apt
+
+# Programming dependencies
+RUN apt-get update && eatmydata apt-get install dfu-util --no-install-recommends -y && rm -rf /var/lib/apt


### PR DESCRIPTION
dfu-util is a program that implements the host (PC) side of the USB DFU 1.0 and 1.1 (Universal Serial Bus Device Firmware Upgrade) protocol. 